### PR TITLE
Add Build.scala extra imports explanation, v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,32 @@ includeFilter in (Assets, LessKeys.less) := "*.less"
 excludeFilter in (Assets, LessKeys.less) := "_*.less"
 ```
 
+If you're using Build.scala instead of build.sbt, you'll need to import the Assets and LessKeys symbols, in addition to the standard sbt and Play imports: 
+
+```scala
+import sbt._
+import Process._
+import Keys._
+import play.Play.autoImport._
+import PlayKeys._
+import com.typesafe.sbt.web.SbtWeb.autoImport._ 
+import com.typesafe.sbt.less.SbtLess.autoImport._
+
+object ApplicationBuild extends Build {
+
+  val appName = "myproject"
+  val appVersion = "1.0-SNAPSHOT"
+
+  val appDependencies = Seq()
+
+  val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
+    version := appVersion,
+    libraryDependencies ++= appDependencies, 
+    includeFilter in (Assets, LessKeys.less) := "*.less",
+    excludeFilter in (Assets, LessKeys.less) := "_*.less"
+  )
+
+}
+```
+
 &copy; Typesafe Inc., 2013, 2014


### PR DESCRIPTION
To use the includeFilter / exludeFilter examples in Build.scala, the Assets and LessKeys symbols need to be imported.

(re-do of https://github.com/sbt/sbt-less/pull/39 to get it into a single commit)
