### PR TITLE
Fix for issue #23 - source maps should use relative paths to resources i...

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ieCompat            | Do IE compatibility checks.
 insecure            | Allow imports from insecure https hosts.
 maxLineLen          | Maximum line length.
 optimization        | Set the parser's optimization level.
+relativeImports     | Re-write import paths relative to the base less file. Default is true.
 relativeUrls        | Re-write relative urls to the base less file.
 rootpath            | Set rootpath for url rewriting in relative imports and urls.
 silent              | Suppress output of error messages.

--- a/src/main/resources/lessc.js
+++ b/src/main/resources/lessc.js
@@ -43,6 +43,23 @@
             throwIfErr(e);
 
             var writeSourceMap = function (content) {
+              
+                if (options.relativeImports) {
+                    // replace leading part in included assets with "../"
+                    content = JSON.parse(content);
+                    for (var i = 0, s = content.sources, l = s.length; i < l; i++) {
+                        options.paths.forEach(function (path) {
+                            // for windows replace \ with /
+                            path = path.replace(/\\/g, "/");
+                            if (path[path.length - 1] !== "/")
+                                path += "/";
+                            if (s[i].substr(0, path.length) === path)
+                                s[i] = "../" + s[i].substr(path.length);
+                        });
+                    }
+                    content = JSON.stringify(content);
+                }
+              
                 mkdirp(path.dirname(sourceMapOutput), function (e) {
                     throwIfErr(e);
                     fs.writeFile(sourceMapOutput, content, "utf8", throwIfErr);

--- a/src/main/scala/com/typesafe/sbt/less/SbtLess.scala
+++ b/src/main/scala/com/typesafe/sbt/less/SbtLess.scala
@@ -19,6 +19,7 @@ object Import {
     val insecure = SettingKey[Boolean]("less-insecure", "Allow imports from insecure https hosts.")
     val maxLineLen = SettingKey[Int]("less-max-line-len", "Maximum line length.")
     val optimization = SettingKey[Int]("less-optimization", "Set the parser's optimization level.")
+    val relativeImports = SettingKey[Boolean]("less-relative-imports", "Re-write import paths relative to the base less file.")
     val relativeUrls = SettingKey[Boolean]("less-relative-urls", "Re-write relative urls to the base less file.")
     val rootpath = SettingKey[String]("less-rootpath", "Set rootpath for url rewriting in relative imports and urls.")
     val silent = SettingKey[Boolean]("less-silent", "Suppress output of error messages.")
@@ -64,6 +65,7 @@ object SbtLess extends AutoPlugin {
         (sourceDirectories.value ++ resourceDirectories.value ++ webModuleDirectories.value)
           .map(f => JsString(f.getAbsolutePath)).toList
       ),
+      "relativeImports" -> JsBoolean(relativeImports.value),
       "relativeUrls" -> JsBoolean(relativeUrls.value),
       "rootpath" -> JsString(rootpath.value),
       "silent" -> JsBoolean(silent.value),
@@ -86,6 +88,7 @@ object SbtLess extends AutoPlugin {
     insecure := false,
     maxLineLen := -1,
     optimization := 1,
+    relativeImports := true,
     relativeUrls := false,
     rootpath := "",
     silent := false,

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/build.sbt
@@ -1,0 +1,15 @@
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+libraryDependencies += "org.webjars" % "bootstrap" % "3.0.2"
+
+LessKeys.relativeImports := false
+
+val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
+
+checkMapFileContents := {
+  var re = """^.+,"sources":\["main\.less","[^"]+/relative-imports-off/target/web/web-modules/main/webjars/lib/bootstrap/less/mixins\.less"\],.+$""".r
+  val contents = IO.read((WebKeys.public in Assets).value / "main.css.map")
+  if (!re.pattern.matcher(contents).matches) {
+    sys.error(s"Unexpected contents: $contents")
+  }
+}

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/project/build.properties
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.5-RC3

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/project/plugins.sbt
@@ -1,0 +1,7 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+
+resolvers ++= Seq(
+  Resolver.url("sbt snapshot plugins", url("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns),
+  Resolver.sonatypeRepo("snapshots"),
+  "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
+)

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/src/main/assets/main.less
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/src/main/assets/main.less
@@ -1,0 +1,5 @@
+@import "lib/bootstrap/less/mixins.less";
+
+body {
+  .center-block();
+}

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/test
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/test
@@ -1,0 +1,6 @@
+# Compile a less file
+
+> assets
+$ exists target/web/public/main/main.css
+$ exists target/web/public/main/main.css.map
+> checkMapFileContents

--- a/src/sbt-test/sbt-less-plugin/relative-imports/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports/build.sbt
@@ -1,0 +1,12 @@
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+libraryDependencies += "org.webjars" % "bootstrap" % "3.0.2"
+
+val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
+
+checkMapFileContents := {
+  val contents = IO.read((WebKeys.public in Assets).value / "main.css.map")
+  if (contents != """{"version":3,"file":"main.css","sources":["main.less","../lib/bootstrap/less/mixins.less"],"names":[],"mappings":"AAEA;ECsCE,cAAA;EACA,iBAAA;EACA,kBAAA"}""") {
+    sys.error(s"Unexpected contents: $contents")
+  }
+}

--- a/src/sbt-test/sbt-less-plugin/relative-imports/project/build.properties
+++ b/src/sbt-test/sbt-less-plugin/relative-imports/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.5-RC3

--- a/src/sbt-test/sbt-less-plugin/relative-imports/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports/project/plugins.sbt
@@ -1,0 +1,7 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+
+resolvers ++= Seq(
+  Resolver.url("sbt snapshot plugins", url("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns),
+  Resolver.sonatypeRepo("snapshots"),
+  "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
+)

--- a/src/sbt-test/sbt-less-plugin/relative-imports/src/main/assets/main.less
+++ b/src/sbt-test/sbt-less-plugin/relative-imports/src/main/assets/main.less
@@ -1,0 +1,5 @@
+@import "lib/bootstrap/less/mixins.less";
+
+body {
+  .center-block();
+}

--- a/src/sbt-test/sbt-less-plugin/relative-imports/test
+++ b/src/sbt-test/sbt-less-plugin/relative-imports/test
@@ -1,0 +1,6 @@
+# Compile a less file
+
+> assets
+$ exists target/web/public/main/main.css
+$ exists target/web/public/main/main.css.map
+> checkMapFileContents


### PR DESCRIPTION
...ncluded from webjars
- included assets absolute paths are now replaced with '../' prefix in writeSourceMap() handler
