### PR TITLE
Add dependency on nodeModules

### DIFF
--- a/src/main/scala/com/typesafe/sbt/less/SbtLess.scala
+++ b/src/main/scala/com/typesafe/sbt/less/SbtLess.scala
@@ -129,8 +129,12 @@ object SbtLess extends AutoPlugin {
         taskMessage in TestAssets := "LESS test compiling"
       )
   ) ++ SbtJsTask.addJsSourceFileTasks(less) ++ Seq(
-    less in Assets := (less in Assets).dependsOn(webModules in Assets).value,
-    less in TestAssets := (less in TestAssets).dependsOn(webModules in TestAssets).value
+    less in Assets := (less in Assets).dependsOn(
+      webModules in Assets, nodeModules in Assets
+    ).value,
+    less in TestAssets := (less in TestAssets).dependsOn(
+      webModules in TestAssets, nodeModules in TestAssets
+    ).value
   )
 
 }


### PR DESCRIPTION
In 460b3a5, I added the ability to import less sources from NPM modules.
However, the source tasks did not depend on the nodeModules task, so
builds could fail if the modules had not already been pulled into
$PROJECT_ROOT/node_modules.

This was hidden by the fact that most builds using NPM have other tasks
that fetch NPM modules, so the bug tended to show up only on the first
build in fresh checkouts.
