### PR TITLE
README to suggest using the latest plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the scripts to verify. js-engine enables high performance linting given parallel
 To use this plugin use the addSbtPlugin command within your project's plugins.sbt (or as a global setting) i.e.:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.1")
 ```
 
 Your project's build file also needs to enable sbt-web plugins. For example with build.sbt:


### PR DESCRIPTION
A trivial change in the readme.

I've ran into several issues, that I've found out later, are already fixed in the newest version. Though I had been using an older one.