### PR TITLE
Honour sbt plugin’s cleancss option.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ lazy val `sbt-less` = project in file(".")
 description := "sbt-web less plugin"
 
 libraryDependencies ++= Seq(
-  "org.webjars" % "less-node" % "2.5.0",
-  "org.webjars" % "source-map" % "0.1.40-1",
+  "org.webjars" % "less-node" % "2.7.2",
   "org.webjars" % "mkdirp" % "0.5.0",
-  "org.webjars" % "clean-css" % "2.2.7",
+  "org.webjars.npm" % "clean-css" % "4.0.5",
+  "org.webjars.npm" % "less-plugin-clean-css" % "1.5.1" intransitive(),
   "org.webjars" % "es6-promise-node" % "2.1.1"
 )
 

--- a/src/main/resources/lessc.js
+++ b/src/main/resources/lessc.js
@@ -56,7 +56,14 @@
             sourceMapOutputFilename: path.basename(outputFile)
         };
         options.filename = input;
-        options.plugins = [];
+
+        if (options.cleancss) {
+            var LessPluginCleanCSS = require('less-plugin-clean-css');
+            var cleanCSSPlugin = new LessPluginCleanCSS();
+            options.plugins = [cleanCSSPlugin];
+        } else {
+            options.plugins = [];
+        }
 
         var writeSourceMap = function (content, onDone) {
             if (content) { // NOTE: this is workaround for https://github.com/less/less.js/issues/2430

--- a/src/sbt-test/sbt-less-plugin/clean-css/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/clean-css/build.sbt
@@ -1,0 +1,14 @@
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+LessKeys.cleancss := true
+
+val checkCleanCssUsed = taskKey[Unit]("check that clean-css has been used")
+
+checkCleanCssUsed := {
+  val contents = IO.read((WebKeys.public in Assets).value / "css" / "main.css")
+  val expectedContents = """h1{color:#00f}"""
+
+  if (contents != expectedContents) {
+    sys.error(s"Unexpected contents: $contents, \nexpected: $expectedContents")
+  }
+}

--- a/src/sbt-test/sbt-less-plugin/clean-css/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/clean-css/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+
+resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/clean-css/src/main/assets/css/main.less
+++ b/src/sbt-test/sbt-less-plugin/clean-css/src/main/assets/css/main.less
@@ -1,0 +1,3 @@
+h1 {
+  color: blue;
+}

--- a/src/sbt-test/sbt-less-plugin/clean-css/test
+++ b/src/sbt-test/sbt-less-plugin/clean-css/test
@@ -1,0 +1,5 @@
+# Compile with clean-css
+
+> assets
+> checkCleanCssUsed
+


### PR DESCRIPTION
I can't see how clean-css could have _ever_ worked with sbt-less. I've added a test to demonstrate that it works once we use less-plugin-clean-css.