### PR TITLE
Change README to point to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the scripts to verify. js-engine enables high performance linting given parallel
 To use this plugin use the addSbtPlugin command within your project's plugins.sbt (or as a global setting) i.e.:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.1")
 ```
 
 Your project's build file also needs to enable sbt-web plugins. For example with build.sbt:


### PR DESCRIPTION
I ran into Issue #81. With this change, future users won't need to.