### PR TITLE
Write a sourcemap file when content is defined

### DIFF
--- a/src/main/resources/lessc.js
+++ b/src/main/resources/lessc.js
@@ -82,12 +82,12 @@
                     }
                     content = JSON.stringify(content);
                 }
-            }
 
-            mkdirp(path.dirname(sourceMapOutput), function (e) {
-                throwIfErr(e);
-                fs.writeFile(sourceMapOutput, content, "utf8", onDone);
-            });
+                mkdirp(path.dirname(sourceMapOutput), function (e) {
+                    throwIfErr(e);
+                    fs.writeFile(sourceMapOutput, content, "utf8", onDone);
+                });
+            }
         };
 
 


### PR DESCRIPTION
Fixes 
- #105.

Tested with node v18.16.1: the styles compiled without an error.
