### PR TITLE
Bump sbt-web-build-base to 2.0.1. Fixes #118

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ project/plugins/project/
 # Idea
 .idea/
 .idea_modules/
+
+.bsp/

--- a/build.sbt
+++ b/build.sbt
@@ -9,5 +9,5 @@ libraryDependencies ++= Seq(
   "org.webjars" % "es6-promise-node" % "2.1.1"
 )
 
-addSbtJsEngine("1.3.3")
-addSbtWeb("1.5.2")
+addSbtJsEngine("1.3.5")
+addSbtWeb("1.5.3")

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val `sbt-less` = project in file(".")
+lazy val `sbt-less` = (project in file(".")).enablePlugins(SbtWebBase)
 description := "sbt-web less plugin"
 
 libraryDependencies ++= Seq(
@@ -9,5 +9,5 @@ libraryDependencies ++= Seq(
   "org.webjars" % "es6-promise-node" % "2.1.1"
 )
 
-addSbtJsEngine("1.2.2")
-addSbtWeb("1.4.3")
+addSbtJsEngine("1.3.3")
+addSbtWeb("1.5.2")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.9.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.9.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-web-build-base" % "1.2.0")
+addSbtPlugin("com.github.sbt" % "sbt-web-build-base" % "2.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.github.sbt" % "sbt-web-build-base" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-web-build-base" % "2.0.2")

--- a/sbt-less-plugin-tester/build.sbt
+++ b/sbt-less-plugin-tester/build.sbt
@@ -4,6 +4,6 @@ lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
 libraryDependencies += "org.webjars" % "bootstrap" % "3.0.2"
 
-LessKeys.compress in Assets := false
+Assets / LessKeys.compress := false
 
-includeFilter in (Assets, LessKeys.less) := "foo.less" | "bar.less"
+Assets / LessKeys.less / includeFilter := "foo.less" | "bar.less"

--- a/sbt-less-plugin-tester/project/build.properties
+++ b/sbt-less-plugin-tester/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.9.7

--- a/sbt-less-plugin-tester/project/plugins.sbt
+++ b/sbt-less-plugin-tester/project/plugins.sbt
@@ -1,3 +1,3 @@
-lazy val root = Project("plugins", file(".")).dependsOn(plugin)
+lazy val plugin = RootProject(file("..").getAbsoluteFile.toURI)
 
-lazy val plugin = file("../").getCanonicalFile.toURI
+lazy val root = (project in file(".")).dependsOn(plugin)

--- a/sbt-less-plugin-tester/project/plugins.sbt
+++ b/sbt-less-plugin-tester/project/plugins.sbt
@@ -1,5 +1,3 @@
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 
 lazy val plugin = file("../").getCanonicalFile.toURI
-
-resolvers += Resolver.mavenLocal

--- a/src/main/resources/lessc.js
+++ b/src/main/resources/lessc.js
@@ -82,12 +82,14 @@
                     }
                     content = JSON.stringify(content);
                 }
-            }
 
-            mkdirp(path.dirname(sourceMapOutput), function (e) {
-                throwIfErr(e);
-                fs.writeFile(sourceMapOutput, content, "utf8", onDone);
-            });
+                mkdirp(path.dirname(sourceMapOutput), function (e) {
+                    throwIfErr(e);
+                    fs.writeFile(sourceMapOutput, content, "utf8", onDone);
+                });
+            } else {
+              onDone()
+            }
         };
 
 

--- a/src/main/scala/com/typesafe/sbt/less/SbtLess.scala
+++ b/src/main/scala/com/typesafe/sbt/less/SbtLess.scala
@@ -129,15 +129,15 @@ object SbtLess extends AutoPlugin {
       inConfig(Assets)(lessUnscopedSettings) ++
       inConfig(TestAssets)(lessUnscopedSettings) ++
       Seq(
-        taskMessage in Assets := "LESS compiling",
-        taskMessage in TestAssets := "LESS test compiling"
+        (Assets / taskMessage) := "LESS compiling",
+        (TestAssets / taskMessage) := "LESS test compiling"
       )
   ) ++ SbtJsTask.addJsSourceFileTasks(less) ++ Seq(
-    less in Assets := (less in Assets).dependsOn(
-      webModules in Assets, nodeModules in Assets
+    Assets / less := (Assets / less).dependsOn(
+      Assets / webModules, Assets / nodeModules
     ).value,
-    less in TestAssets := (less in TestAssets).dependsOn(
-      webModules in TestAssets, nodeModules in TestAssets
+    TestAssets / less := (TestAssets / less).dependsOn(
+      TestAssets / webModules, TestAssets / nodeModules
     ).value
   )
 

--- a/src/sbt-test/sbt-less-plugin/bootstrap/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/bootstrap/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/bootstrap/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/bootstrap/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/clean-css/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/clean-css/build.sbt
@@ -5,7 +5,7 @@ LessKeys.cleancss := true
 val checkCleanCssUsed = taskKey[Unit]("check that clean-css has been used")
 
 checkCleanCssUsed := {
-  val contents = IO.read((WebKeys.public in Assets).value / "css" / "main.css")
+  val contents = IO.read((Assets / WebKeys.public).value / "css" / "main.css")
   val expectedContents = """h1{color:#00f}"""
 
   if (contents != expectedContents) {

--- a/src/sbt-test/sbt-less-plugin/clean-css/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/clean-css/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/clean-css/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/clean-css/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/empty-source/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/empty-source/build.sbt
@@ -1,11 +1,11 @@
 lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
-includeFilter in(Assets, LessKeys.less) := "empty.less"
+(Assets / LessKeys.less / includeFilter) := "empty.less"
 
 val checkFileContents = taskKey[Unit]("Check for emptiness")
 
 checkFileContents := {
-  val contents = IO.read((WebKeys.public in Assets).value / "css" / "empty.css")
+  val contents = IO.read((Assets / WebKeys.public).value / "css" / "empty.css")
 
   if (contents.nonEmpty) {
     sys.error(s"Output should be empty, but got '$contents'")

--- a/src/sbt-test/sbt-less-plugin/empty-source/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/empty-source/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/empty-source/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/empty-source/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/error-output-global-vars/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/error-output-global-vars/build.sbt
@@ -14,7 +14,7 @@ errors := TrieMap.empty
 
 WebKeys.reporter := new Compat.CapturingLoggerReporter(streams.value.log, errors.value)
 
-includeFilter in (Assets, less) := GlobFilter("*.less")
+(Assets / less / includeFilter) := GlobFilter("*.less")
 
 InputKey[Unit]("errorExists") := {
   val args = Def.spaceDelimited("<file> <line> <column>").parsed

--- a/src/sbt-test/sbt-less-plugin/error-output-global-vars/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/error-output-global-vars/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/error-output-global-vars/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/error-output-global-vars/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/error-output/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/error-output/build.sbt
@@ -12,7 +12,7 @@ errors := TrieMap.empty
 
 WebKeys.reporter := new Compat.CapturingLoggerReporter(streams.value.log, errors.value)
 
-includeFilter in (Assets, less) := GlobFilter("*.less")
+(Assets / less / includeFilter) := GlobFilter("*.less")
 
 InputKey[Unit]("errorExists") := {
   val args = Def.spaceDelimited("<file> <line> <column>").parsed

--- a/src/sbt-test/sbt-less-plugin/error-output/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/error-output/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/error-output/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/error-output/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/error-output/test
+++ b/src/sbt-test/sbt-less-plugin/error-output/test
@@ -9,7 +9,7 @@
 
 > errorExists    missing-variable.less 2 16
 > errorMsg       missing-variable.less variable @heading-font-family is undefined
-> errorContents  missing-variable.less font-family: @heading-font-family;
+> errorContents  missing-variable.less "font-family: @heading-font-family;"
 
 > resetErrors
 
@@ -25,4 +25,4 @@
 
 > errorExists    missing-variable.less 2 16
 > errorMsg       missing-variable.less variable @heading-font-family is undefined
-> errorContents  missing-variable.less font-family: @heading-font-family;
+> errorContents  missing-variable.less "font-family: @heading-font-family;"

--- a/src/sbt-test/sbt-less-plugin/global-variables/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/global-variables/build.sbt
@@ -5,7 +5,7 @@ LessKeys.globalVariables := Seq("color" -> "blue")
 val checkFileContents = taskKey[Unit]("Check for the presence of a variable")
 
 checkFileContents := {
-  val contents = IO.read((WebKeys.public in Assets).value / "css" / "main.css")
+  val contents = IO.read((Assets / WebKeys.public).value / "css" / "main.css")
   val expected = "color: blue"
 
   if (!contents.contains(expected)) {

--- a/src/sbt-test/sbt-less-plugin/global-variables/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/global-variables/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/global-variables/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/global-variables/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/incremental-compilation/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/incremental-compilation/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/incremental-compilation/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/incremental-compilation/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/less/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/less/build.sbt
@@ -3,7 +3,7 @@ lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
 
 checkMapFileContents := {
-  val contents = IO.read((WebKeys.public in Assets).value / "css" / "main.min.css.map")
+  val contents = IO.read((Assets / WebKeys.public).value / "css" / "main.min.css.map")
   val expectedContents = """{"version":3,"sources":["main.less"],"names":[],"mappings":"AAAA,GACE","file":"main.min.css"}"""
 
   if (contents != expectedContents) {

--- a/src/sbt-test/sbt-less-plugin/less/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/less/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/less/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/less/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/less/test
+++ b/src/sbt-test/sbt-less-plugin/less/test
@@ -6,7 +6,7 @@ $ exists target/web/public/main/css/main.css.map
 
 # Compile with compression
 
-> set LessKeys.compress in Assets := true
+> set Assets / LessKeys.compress := true
 > assets
 -$ exists target/web/public/main/css/main.css
 -$ exists target/web/public/main/css/main.css.map
@@ -15,7 +15,7 @@ $ exists target/web/public/main/css/main.min.css.map
 > checkMapFileContents
 
 # Compile without sourceMaps
-> set LessKeys.sourceMap in Assets := false
+> set Assets / LessKeys.sourceMap := false
 > assets
 $ exists target/web/public/main/css/main.min.css
 -$ exists target/web/public/main/css/main.min.css.map

--- a/src/sbt-test/sbt-less-plugin/multi-module/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/multi-module/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/multi-module/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/multi-module/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/build.sbt
@@ -8,7 +8,7 @@ val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
 
 checkMapFileContents := {
   var re = """^.+,"sources":\["main\.less","[^"]+/relative-imports-off/target/web/web-modules/main/webjars/lib/bootstrap/less/mixins\.less"\],.+$""".r
-  val contents = IO.read((WebKeys.public in Assets).value / "main.css.map")
+  val contents = IO.read((Assets / WebKeys.public).value / "main.css.map")
   if (!re.pattern.matcher(contents).matches) {
     sys.error(s"Unexpected contents: $contents")
   }

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/build.sbt
@@ -7,7 +7,7 @@ LessKeys.relativeImports := false
 val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
 
 checkMapFileContents := {
-  var re = """^.+,"sources":\["main\.less","[^"]+/relative-imports-off/target/web/web-modules/main/webjars/lib/bootstrap/less/mixins\.less"\],.+$""".r
+  var re = """^.+,"sources":\["main\.less","[^"]+/sbt_[^"]+/target/web/web-modules/main/webjars/lib/bootstrap/less/mixins\.less"\],.+$""".r
   val contents = IO.read((Assets / WebKeys.public).value / "main.css.map")
   if (!re.pattern.matcher(contents).matches) {
     sys.error(s"Unexpected contents: $contents")

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/relative-imports-off/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports-off/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/relative-imports/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies += "org.webjars" % "bootstrap" % "3.0.2"
 val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
 
 checkMapFileContents := {
-  val contents = IO.read((WebKeys.public in Assets).value / "main.css.map")
+  val contents = IO.read((Assets / WebKeys.public).value / "main.css.map")
   val expectedContents = """{"version":3,"sources":["main.less","../lib/bootstrap/less/mixins.less"],"names":[],"mappings":"AAEA;ECsCE,cAAA;EACA,iBAAA;EACA,kBAAA","file":"main.css"}"""
 
   if (contents != expectedContents) {

--- a/src/sbt-test/sbt-less-plugin/relative-imports/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
 
 resolvers += Resolver.mavenLocal

--- a/src/sbt-test/sbt-less-plugin/relative-imports/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/relative-imports/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
-
-resolvers += Resolver.mavenLocal

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.3-SNAPSHOT"
+version := "1.1.3-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

As discussed in #118 the latest version of `sbt-less` appears to be incompatible with the latest version of `sbt-web`. To resolve this we need to update the `sbt-web-build-base` version.

This change does a couple of things:
* Bumps `sbt-web-build-base` to 2.0.1
* The latest version of the base plugin allowed us to also bump versions of plugins `sbt-js-engine` and `sbt-web`
* Bumps sbt to 1.9.6 (this is the minimum sbt version specified by [sbt-web-build-base](https://github.com/sbt/sbt-web-build-base#usage)) 
* Given the latest version of sbt is used, `SbtLess` is refactored to use slash syntax
* To ensure the tests can still be executed, the groupId of plugins used in tests have also been updated

## How to test?

It appears as though this project makes use of the sbt [scripted](https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html) test framework for testing sbt plugins.

To test changes we can run `sbt scripted`.

~~I tested locally by doing the following:~~
~~* Publishing a version of the plugin to local maven (`sbt publishM2`)~~
~~* For each project inside `./sbt-test/sbt-less-plugin`:~~
~~* Ensuring the project compiles and uses the locally published version of the plugin~~
~~* Execute the test instructions and confirm the expectations succeed~~

Note that some tests failed, e.g.:
<img width="1255" alt="image" src="https://github.com/sbt/sbt-less/assets/45561419/e7d95031-9a65-41f9-b178-8e04c534f875">

I don't believe these errors are caused by this change because I believe this issue has already been [reported](https://github.com/sbt/sbt-less/issues/105) and there is an open [PR](https://github.com/sbt/sbt-less/pull/116) to resolve this. Please correct me if I'm wrong!
