### PR TITLE
Handle multiple extracted versions of same webjarFallback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,12 +17,13 @@ addSbtJsEngine("1.3.5")
 addSbtWeb("1.5.3")
 
 libraryDependencies ++= Seq(
-  "org.webjars.npm" % "less" % "4.2.0",
+  "org.webjars.npm" % "node-require-fallback" % "1.0.0",
+  "org.webjars.npm" % "less" % "4.2.0", // sync with src/main/resources/lessc.js
   "org.webjars.npm" % "clone" % "2.1.2",
-  "org.webjars.npm" % "mkdirp" % "0.5.6",
+  "org.webjars.npm" % "mkdirp" % "0.5.6", // sync with src/main/resources/lessc.js
   "org.webjars.npm" % "clean-css" % "5.3.2",
-  "org.webjars.npm" % "less-plugin-clean-css" % "1.5.1" intransitive(),
-  "org.webjars.npm" % "es6-promise" % "4.2.8"
+  "org.webjars.npm" % "less-plugin-clean-css" % "1.5.1" intransitive(), // sync with src/main/resources/lessc.js
+  "org.webjars.npm" % "es6-promise" % "4.2.8", // sync with src/main/resources/lessc.js
 )
 
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed

--- a/src/main/resources/lessc.js
+++ b/src/main/resources/lessc.js
@@ -4,18 +4,20 @@
 
     "use strict";
 
+    var requireIfExists = require('node-require-fallback')
+
     // Ensure we have a promise implementation.
     //
     if (typeof Promise === 'undefined') {
-        var Promise = require("es6-promise").Promise;
+        var Promise = requireIfExists("es6-promise/4.2.8", "es6-promise").Promise; // sync with build.sbt
         global.Promise = Promise;
     }
 
     var args = process.argv,
         os = require("os"),
         fs = require("fs"),
-        less = require("less"),
-        mkdirp = require("mkdirp"),
+        less = requireIfExists("less/4.2.0", "less"), // sync with build.sbt
+        mkdirp = requireIfExists("mkdirp/0.5.6", "mkdirp"), // sync with build.sbt
         path = require("path");
 
     var SOURCE_FILE_MAPPINGS_ARG = 2;
@@ -58,7 +60,7 @@
         options.filename = input;
 
         if (options.cleancss) {
-            var LessPluginCleanCSS = require('less-plugin-clean-css');
+            var LessPluginCleanCSS = requireIfExists("less-plugin-clean-css/1.5.1", "less-plugin-clean-css"); // sync with build.sbt
             var cleanCSSPlugin = new LessPluginCleanCSS();
             options.plugins = [cleanCSSPlugin];
         } else {

--- a/src/sbt-test/sbt-less-plugin/less-same-webjars-different-version/build.sbt
+++ b/src/sbt-test/sbt-less-plugin/less-same-webjars-different-version/build.sbt
@@ -1,0 +1,12 @@
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
+
+checkMapFileContents := {
+  val contents = IO.read((Assets / WebKeys.public).value / "css" / "main.min.css.map")
+  val expectedContents = """{"version":3,"sources":["main.less"],"names":[],"mappings":"AAAA,GACE","file":"main.min.css"}"""
+
+  if (contents != expectedContents) {
+    sys.error(s"Unexpected contents: $contents, \nexpected: $expectedContents")
+  }
+}

--- a/src/sbt-test/sbt-less-plugin/less-same-webjars-different-version/project/plugins.sbt
+++ b/src/sbt-test/sbt-less-plugin/less-same-webjars-different-version/project/plugins.sbt
@@ -1,0 +1,29 @@
+addSbtPlugin("com.github.sbt" % "sbt-less" % sys.props("project.version"))
+
+// When the same webjar (= same name) from different groupIds (org.webjars[.npm|bower]?)
+// are are on the classpath, those webjars get extracted into subfolders which are named by the version of the webjar.
+// However, if there is just one type (npm, bower, classic) of a webjar on the classpath, NO subfolders gets created.
+// Now, because in a project we don't know which other webjars get pulled in from other dependencies, it can happen
+// that subfolders get created, or may not. However, require(...) can't know that and therefore has to look in both places.
+// To test that the lookup is correct, we force this scripted test to create subfolders by pulling in the same webjar
+// but from different groupIds (the other scripted test does not do that and therefore no subfolders get created there)
+// btw: dependency eviction within the same type of webjar still works correctly, so e.g. 0.2 wins over 0.1 within the same type of webjar
+// and no subfolder will be forced for that case but the newest version will be choosen. Like normal dependency resolution.
+libraryDependencies ++= Seq(
+  // Pulling in the classic and the npm webjar to subfolders for this webjar will be created
+  "org.webjars" % "mkdirp" % "0.3.5",
+  "org.webjars.npm" % "mkdirp" % "0.5.1",
+
+  // Same here, we pull in the bower and the npm one so subfolders will be created
+  // ("3.8.1/ and 3.8.1 etc.)
+  "org.webjars" % "less" % "3.8.1",
+  "org.webjars.npm" % "less" % "3.8.1",
+
+
+  // and so on...
+  "org.webjars.npm" % "es6-promise" % "4.1.0",
+  "org.webjars" % "es6-promise" % "2.1.1",
+
+  "org.webjars.npm" % "less-plugin-clean-css" % "1.5.1" intransitive(),
+  // TODO: there was no other webjars type for less-plugin-clean-css currently
+)

--- a/src/sbt-test/sbt-less-plugin/less-same-webjars-different-version/src/main/assets/css/main.less
+++ b/src/sbt-test/sbt-less-plugin/less-same-webjars-different-version/src/main/assets/css/main.less
@@ -1,0 +1,3 @@
+h1 {
+  color: blue
+}

--- a/src/sbt-test/sbt-less-plugin/less-same-webjars-different-version/test
+++ b/src/sbt-test/sbt-less-plugin/less-same-webjars-different-version/test
@@ -1,0 +1,21 @@
+# Compile a less file
+
+> assets
+$ exists target/web/public/main/css/main.css
+$ exists target/web/public/main/css/main.css.map
+
+# Compile with compression
+
+> set Assets / LessKeys.compress := true
+> assets
+-$ exists target/web/public/main/css/main.css
+-$ exists target/web/public/main/css/main.css.map
+$ exists target/web/public/main/css/main.min.css
+$ exists target/web/public/main/css/main.min.css.map
+> checkMapFileContents
+
+# Compile without sourceMaps
+> set Assets / LessKeys.sourceMap := false
+> assets
+$ exists target/web/public/main/css/main.min.css
+-$ exists target/web/public/main/css/main.min.css.map


### PR DESCRIPTION
Those webjars get extracted in subfolders.

See lengthy comment in `plugins.sbt` of this pull request.

- Same as in https://github.com/sbt/sbt-coffeescript/pull/33